### PR TITLE
Fixed 2 files needed to compile in linux

### DIFF
--- a/RiotGear/Properties/Resources.resx
+++ b/RiotGear/Properties/Resources.resx
@@ -122,19 +122,19 @@
     <value>..\Query\player.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableRunePage" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\query\runepage.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Query\runePage.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableRuneSlot" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\query\runeslot.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Query\runeSlot.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableSummoner" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Query\summoner.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableSummonerRankedStatistics" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\query\summonerrankedstatistics.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Query\summonerRankedStatistics.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableSummonerRating" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\query\summonerrating.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Query\summonerRating.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CreateTableUnknownPlayer" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Query\unknownPlayer.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>

--- a/RiotShield/RiotShield.csproj
+++ b/RiotShield/RiotShield.csproj
@@ -58,7 +58,7 @@
       <HintPath>..\References\Nil.dll</HintPath>
     </Reference>
     <Reference Include="RiotGear">
-      <HintPath>..\RiotGear\bin\x86\Debug\RiotGear.dll</HintPath>
+      <HintPath>..\RiotGear\bin\Debug\RiotGear.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Web/Script/Module/Rendering.js
+++ b/Web/Script/Module/Rendering.js
@@ -14,7 +14,7 @@ function render()
 function renderWithSearchForm()
 {
     var items = parseArguments(arguments);
-    if(hasSetAutomaticUpdatesPrivilege())
+    if(hasSearchPrivilege())
         items = [getSearchFormContainer()].concat(items);
     render(items);
 }

--- a/Web/Script/Module/SummonerOverview.js
+++ b/Web/Script/Module/SummonerOverview.js
@@ -63,13 +63,17 @@ function getSummonerOverview(summoner, statistics)
     if(hasRunesPrivilege())
         overviewFields2.push(['Runes', viewRunesLink]);
 
+    if(hasUpdatePrivilege())
+    {
+	var manualUpdateContainer = span();
+        manualUpdateContainer.add(anchor('Update now', function() { updateSummoner(manualUpdateContainer, region, summoner.AccountId); } ));
+        overviewFields2.push(['Manual update', manualUpdateContainer]);
+    }
+
     var updateDescription = 'Is updated automatically';
     if(hasSetAutomaticUpdatesPrivilege())
     {
         //Requesting updates requires writing permissions
-        var manualUpdateContainer = span();
-        manualUpdateContainer.add(anchor('Update now', function() { updateSummoner(manualUpdateContainer, region, summoner.AccountId); } ));
-        overviewFields2.push(['Manual update', manualUpdateContainer]);
         var automaticUpdateContainer = span();
         automaticUpdateContainer.add(getAutomaticUpdateDescription(automaticUpdateContainer, region, summoner));
         overviewFields2.push([updateDescription, automaticUpdateContainer]);

--- a/Web/Script/Module/Utility.js
+++ b/Web/Script/Module/Utility.js
@@ -75,7 +75,8 @@ function padWithZeroes(number, zeroes)
 
 function getTimestampString(timestamp)
 {
-    var date = getDateFromTimestamp(timestamp);
+    var dateOffset = new Date().getTimezoneOffset();
+    var date = getDateFromTimestamp(timestamp - dateOffset * 60);
     return date.getUTCFullYear() + '-' + padWithZeroes(date.getUTCMonth() + 1) + '-' + padWithZeroes(date.getUTCDate()) + ' ' + padWithZeroes(date.getUTCHours()) + ':' + padWithZeroes(date.getUTCMinutes()) + ':' + padWithZeroes(date.getUTCSeconds());
 }
 


### PR DESCRIPTION
These changes allow for a successful compilation of RiotGear and RiotShield in linux (with mono's xbuild). To compile RiotUpdate you would need to fix another file that most likely would break compilation in Windows, so I am not requesting a pull of that file. Look in my repo if needed (master branch).
